### PR TITLE
Add optional argument 'skipempty' to split function

### DIFF
--- a/doc/source/stdlib/stdstringlib.rst
+++ b/doc/source/stdlib/stdstringlib.rst
@@ -50,17 +50,20 @@ Global Symbols
     Strips white-space-only characters that might appear at the end of the given string
     and returns the new stripped string.
 
-.. sq:function:: split(str, separators)
+.. js:function:: split(str, separators [, skipempty])
 
     returns an array of strings split at each point where a separator character occurs in `str`.
     The separator is not returned as part of any array element.
     The parameter `separators` is a string that specifies the characters as to be used for the splitting.
+    The parameter `skipempty` is a boolean (default false). If `skipempty` is true, empty strings are not added to array.
 
     ::
 
         eg.
-        local a = split("1.2-3;4/5",".-/;");
-        // the result will be  [1,2,3,4,5]
+        local a = split("1.2-3;;4/5",".-/;");
+        // the result will be  [1,2,3,,4,5]
+        or
+        local b = split("1.2-3;;4/5",".-/;",true);
 
 
 .. sq:function:: startswith(str, cmp)

--- a/sqstdlib/sqstdstring.cpp
+++ b/sqstdlib/sqstdstring.cpp
@@ -249,16 +249,16 @@ static SQInteger _string_rstrip(HSQUIRRELVM v)
 static SQInteger _string_split(HSQUIRRELVM v)
 {
     const SQChar *str,*seps;
-    SQChar *stemp;
+    SQInteger sepsize;
+    SQBool skipempty = SQFalse;
     sq_getstring(v,2,&str);
-    sq_getstring(v,3,&seps);
-    SQInteger sepsize = sq_getsize(v,3);
+    sq_getstringandsize(v,3,&seps,&sepsize);
     if(sepsize == 0) return sq_throwerror(v,_SC("empty separators string"));
-    SQInteger memsize = (sq_getsize(v,2)+1)*sizeof(SQChar);
-    stemp = sq_getscratchpad(v,memsize);
-    memcpy(stemp,str,memsize);
-    SQChar *start = stemp;
-    SQChar *end = stemp;
+    if(sq_gettop(v)>3) {
+        sq_getbool(v,4,&skipempty);
+    }
+    const SQChar *start = str;
+    const SQChar *end = str;
     sq_newarray(v,0);
     while(*end != '\0')
     {
@@ -267,9 +267,10 @@ static SQInteger _string_split(HSQUIRRELVM v)
         {
             if(cur == seps[i])
             {
-                *end = 0;
-                sq_pushstring(v,start,-1);
-                sq_arrayappend(v,-2);
+                if(!skipempty || (end != start)) {
+                    sq_pushstring(v,start,end-start);
+                    sq_arrayappend(v,-2);
+                }
                 start = end + 1;
                 break;
             }
@@ -278,7 +279,7 @@ static SQInteger _string_split(HSQUIRRELVM v)
     }
     if(end != start)
     {
-        sq_pushstring(v,start,-1);
+        sq_pushstring(v,start,end-start);
         sq_arrayappend(v,-2);
     }
     return 1;
@@ -510,7 +511,7 @@ static const SQRegFunction stringlib_funcs[]={
     _DECL_FUNC(strip,2,_SC(".s")),
     _DECL_FUNC(lstrip,2,_SC(".s")),
     _DECL_FUNC(rstrip,2,_SC(".s")),
-    _DECL_FUNC(split,3,_SC(".ss")),
+    _DECL_FUNC(split,-3,_SC(".ssb")),
     _DECL_FUNC(escape,2,_SC(".s")),
     _DECL_FUNC(startswith,3,_SC(".ss")),
     _DECL_FUNC(endswith,3,_SC(".ss")),


### PR DESCRIPTION
port from original squirrel