### PR TITLE
quirrel: remove filter_inplace method of array

### DIFF
--- a/doc/source/reference/diff_from_original.rst
+++ b/doc/source/reference/diff_from_original.rst
@@ -36,7 +36,7 @@ New features
 * string default delegates: .subst(), .replace(), .join(), .split(), .concat() methods added
 * table default delegates: .map(), .each(), .findindex(), .findvalue(), .reduce(),
   __merge(), .__update() methods added
-* array default delegates: .each(), .findvalue(), .filter_inplace()  methods added
+* array default delegates: .each(), .findvalue(), .replace()  methods added
 * Support negative indexes in array.slice()
 * Compiler directives for stricter and thus safer language (some of them can be used to test upcoming or planned language changes)
 * Added C APIs not using stack pushes/pops

--- a/doc/source/reference/language/builtin_functions.rst
+++ b/doc/source/reference/language/builtin_functions.rst
@@ -588,11 +588,6 @@ Finally, returns the return value of the last invocation of func.
 
 Creates a new array with all elements that pass the test implemented by the provided function. In detail, it creates a new array, for each element in the original array invokes the specified function passing the index of the element and it's value; if the function returns 'true', then the value of the corresponding element is added on the newly created array.
 
-.. sq:function:: array.filter_inplace(func(val, [index], [array_ref]))
-
-Similar to array.filter(), but modifies given array instead of creating new one.
-It removes all elements for which provided function returns false.
-
 .. sq:function:: array.indexof(value)
 
 Performs a linear search for the value in the array. Returns the index of the value if it was found null otherwise.

--- a/squirrel/sqbaselib.cpp
+++ b/squirrel/sqbaselib.cpp
@@ -1136,35 +1136,6 @@ static SQInteger array_filter(HSQUIRRELVM v)
     return 1;
 }
 
-static SQInteger array_filter_inplace(HSQUIRRELVM v)
-{
-    SQObject &o = stack_get(v,1);
-    SQArray *a = _array(o);
-    SQObject &closure = stack_get(v, 2);
-    SQInteger nArgs = get_allowed_args_count(closure, 4);
-
-    SQInteger size = a->Size();
-    SQObjectPtr val;
-    for(SQInteger n = size-1; n >= 0; --n) {
-        a->Get(n,val);
-        v->Push(o);
-        v->Push(val);
-        if (nArgs >= 3)
-            v->Push(n);
-        if (nArgs >= 4)
-            v->Push(o);
-        if(SQ_FAILED(sq_call(v,nArgs,SQTrue,SQFalse))) {
-            return SQ_ERROR;
-        }
-        if(SQVM::IsFalse(v->GetUp(-1))) {
-            a->Remove(n, false);
-        }
-        v->Pop();
-    }
-    a->ShrinkIfNeeded();
-    v->Pop(1);
-    return 1;
-}
 
 static SQInteger array_indexof(HSQUIRRELVM v)
 {
@@ -1343,7 +1314,6 @@ const SQRegFunction SQSharedState::_array_default_delegate_funcz[]={
     {_SC("apply"),array_apply,2, _SC("ac")},
     {_SC("reduce"),array_reduce,-2, _SC("ac.")},
     {_SC("filter"),array_filter,2, _SC("ac")},
-    {_SC("filter_inplace"),array_filter_inplace,2, _SC("ac")},
     {_SC("indexof"),array_indexof,2, _SC("a.")},
     {_SC("each"),container_each,2, _SC("ac")},
     {_SC("findindex"),container_findindex,2, _SC("ac")},


### PR DESCRIPTION
In most cases it is much slower (10-100) times that .filter() (by cost of extra memory)
now the same operation can be done by list.replace(list.filter())
or go with immutability, as it is usually better and cleaner also
