### PR TITLE
Fix issue with null-propagated meta-get access

### DIFF
--- a/squirrel/sqvm.h
+++ b/squirrel/sqvm.h
@@ -72,6 +72,7 @@ public:
 
     void CallDebugHook(SQInteger type,SQInteger forcedline=0);
     void CallErrorHandler(SQObjectPtr &e);
+    SQInteger GetImpl(const SQObjectPtr &self, const SQObjectPtr &key, SQObjectPtr &dest, SQUnsignedInteger getflags, SQInteger selfidx);
     bool Get(const SQObjectPtr &self, const SQObjectPtr &key, SQObjectPtr &dest, SQUnsignedInteger getflags, SQInteger selfidx);
     SQInteger FallBackGet(const SQObjectPtr &self,const SQObjectPtr &key,SQObjectPtr &dest);
     bool InvokeDefaultDelegate(const SQObjectPtr &self,const SQObjectPtr &key,SQObjectPtr &dest);

--- a/testData/testNullPropagation.nut
+++ b/testData/testNullPropagation.nut
@@ -1,0 +1,31 @@
+let class A {
+  function _get(key) {
+    println("begin A._get() call")
+    throw "I am an error!"
+    println("end A._get() call")
+  }
+}
+
+let function testField() {
+  let a = A()
+  println($"a.foo = {a?.foo}")
+}
+
+let function testIndex() {
+  let a = A()
+  println($"a[10] = {a?[10]}")
+}
+
+try {
+  testField()
+  println("testField failed")
+} catch (e) {
+  println("testField passed")
+}
+
+try {
+  testIndex()
+  println("testIndex failed")
+} catch (e) {
+  println("testIndex passed")
+}


### PR DESCRIPTION
In case of failure inside meta-get (_get) method exception was ignored when it shoudn't. Make sure it is being forwared

Also add test to fix that behaviour in the future