### PR TITLE
 Fix call code gen

### DIFF
--- a/squirrel/sqastcodegen.cpp
+++ b/squirrel/sqastcodegen.cpp
@@ -913,11 +913,18 @@ void CodegenVisitor::addLineNumber(Statement *stmt) {
     }
 }
 
+Expr *CodegenVisitor::deparen(Expr *e) const {
+  if (e->op() == TO_PAREN) {
+    return deparen(((UnExpr *)e)->argument());
+  }
+  return e;
+}
+
 void CodegenVisitor::visitCallExpr(CallExpr *call) {
 
     maybeAddInExprLine(call);
 
-    Expr *callee = call->callee();
+    Expr *callee = deparen(call->callee());
     bool isNullCall = call->isNullable();
 
     visitNoGet(callee);

--- a/squirrel/sqastcodegen.h
+++ b/squirrel/sqastcodegen.h
@@ -109,6 +109,8 @@ private:
 
     void selectConstant(SQInteger target, const SQObject &constant);
 
+    Expr *deparen(Expr *e) const;
+
 public:
 
     void visitBlock(Block *block) override;

--- a/testData/parenCallee.nut
+++ b/testData/parenCallee.nut
@@ -1,0 +1,6 @@
+
+let f = @(v) v + 1
+
+let function foo() {
+    return ((((f))))(10)
+}


### PR DESCRIPTION
In case of
```
let f = @(v) v + 1
((f))(10)
```

Paren'ed callee expression handled incorrectly. Deparen it first