### PR TITLE
Take ConstDecl into account when computing scope

### DIFF
--- a/squirrel/optimizations/closureHoisting.cpp
+++ b/squirrel/optimizations/closureHoisting.cpp
@@ -59,6 +59,10 @@ void ClosureHoistingOpt::ScopeComputeVisitor::visitValueDecl(ValueDecl *v) {
   v->visitChildren(this);
 }
 
+void ClosureHoistingOpt::ScopeComputeVisitor::visitConstDecl(ConstDecl *c) {
+  currentScope->declareSymbol(c->name(), c);
+}
+
 void ClosureHoistingOpt::ScopeComputeVisitor::visitTryStatement(TryStatement *stmt) {
   stmt->tryStatement()->visit(this);
   currentScope->declareSymbol(stmt->exceptionId()->id(), NULL);

--- a/squirrel/optimizations/closureHoisting.h
+++ b/squirrel/optimizations/closureHoisting.h
@@ -71,6 +71,7 @@ class ClosureHoistingOpt {
 
     void visitValueDecl(ValueDecl *v);
     void visitTryStatement(TryStatement *stmt);
+    void visitConstDecl(ConstDecl *c);
 
     void visitFunctionDecl(FunctionDecl *decl);
     void visitClassDecl(ClassDecl *klass);

--- a/testData/optimizations/closureHoisting/constDep.nut
+++ b/testData/optimizations/closureHoisting/constDep.nut
@@ -1,0 +1,9 @@
+let function foo() {
+  const x = "asdf"
+  println(x)
+
+  let function bar() {
+    let a = x
+  }
+  bar()
+}

--- a/testData/optimizations/closureHoisting/constDep.opt.txt
+++ b/testData/optimizations/closureHoisting/constDep.opt.txt
@@ -1,0 +1,10 @@
+{
+  let foo = FUNCTION foo(this) {
+    x = "asdf"
+    println(x)
+    let bar = FUNCTION bar(this) {
+      let a = x
+    }
+    bar()
+  }
+}


### PR DESCRIPTION
Add missed visitor for Constants when collecting
declared symbols.

Also add test