### PR TITLE
Fix memory leak in codegen

### DIFF
--- a/squirrel/sqastcodegen.cpp
+++ b/squirrel/sqastcodegen.cpp
@@ -62,9 +62,10 @@ void CodegenVisitor::error(Node *n, const SQChar *s, ...) {
 }
 
 bool CodegenVisitor::generate(RootBlock *root, SQObjectPtr &out) {
+    SQFuncState funcstate(_ss(_vm), NULL, CodegenVisitor::ThrowError, this);
+
     if (setjmp(_errorjmp) == 0) {
 
-        SQFuncState funcstate(_ss(_vm), NULL, CodegenVisitor::ThrowError, this);
         _fs = &funcstate;
         _childFs = NULL;
 


### PR DESCRIPTION
Since stack dtor is not called if program
jumps out on error some parts of memory are not released. Lift object a bit