### PR TITLE
Fix infinite recursion in symbol evaluator

### DIFF
--- a/squirrel/static_analyser/analyser.cpp
+++ b/squirrel/static_analyser/analyser.cpp
@@ -5050,7 +5050,7 @@ const Expr *CheckerVisitor::maybeEval(const Expr *e, int32_t &evalId, std::unord
 
   evalId = v->evalIndex;
   if (v->hasValue()) {
-    return maybeEval(v->expression, evalId);
+    return maybeEval(v->expression, evalId, visited);
   }
   else {
     return e;


### PR DESCRIPTION
Seems like this line was missed in change with ID
9fb0d045bfe2dc76e284e563ef9a329d68a45afa