### PR TITLE
Fix 'named-like-should-return' warning is SA

### DIFF
--- a/squirrel/static_analyser/analyser.cpp
+++ b/squirrel/static_analyser/analyser.cpp
@@ -3606,6 +3606,7 @@ void CheckerVisitor::checkUnutilizedResult(const ExprStatement *s) {
     const Expr *callee = c->callee();
     bool isCtor = false;
     const FunctionInfo *info = findFunctionInfo(callee, isCtor);
+    // check only for functions because instances could have overrided () operator
     if (info) {
       const FunctionDecl *f = info->declaration;
       assert(f);
@@ -3621,18 +3622,6 @@ void CheckerVisitor::checkUnutilizedResult(const ExprStatement *s) {
       report(e, DiagnosticsId::DI_NAME_LIKE_SHOULD_RETURN, "<constructor>");
     }
 
-    const SQChar *calleeName = nullptr;
-
-    if (callee->op() == TO_ID) {
-      calleeName = callee->asId()->id();
-    }
-    else if (callee->op() == TO_GETFIELD) {
-      calleeName = callee->asGetField()->fieldName();
-    }
-
-    if (isCallResultShouldBeUtilized(calleeName, c)) {
-      report(e, DiagnosticsId::DI_NAME_LIKE_SHOULD_RETURN, calleeName);
-    }
     return;
   }
 

--- a/testData/static_analyser/w238.diag.txt
+++ b/testData/static_analyser/w238.diag.txt
@@ -1,9 +1,0 @@
-WARNING: w238 (named-like-should-return) Function name '__merge' implies a return value, but its result is never used.
-testData/static_analyser/w238.nut:4:2
-
-let function x() { //-declared-never-used
-  ::a.__merge(::table2);
-  ^--------------------
-}
-
-

--- a/testData/static_analyser/w238.nut
+++ b/testData/static_analyser/w238.nut
@@ -1,5 +1,0 @@
-//expect:w238
-
-let function x() { //-declared-never-used
-  ::a.__merge(::table2);
-}

--- a/testData/static_analyser/w238_heuristic.diag.txt
+++ b/testData/static_analyser/w238_heuristic.diag.txt
@@ -1,9 +1,0 @@
-WARNING: w238 (named-like-should-return) Function name 'isLoggedIn' implies a return value, but its result is never used.
-testData/static_analyser/w238_heuristic.nut:4:2
-
-let function x() { //-declared-never-used
-  ::isLoggedIn()
-  ^-------------
-}
-
-

--- a/testData/static_analyser/w238_heuristic.nut
+++ b/testData/static_analyser/w238_heuristic.nut
@@ -1,5 +1,0 @@
-//expect:w238
-
-let function x() { //-declared-never-used
-  ::isLoggedIn()
-}


### PR DESCRIPTION
This warn should be reported only for functions