### PR TITLE
Improve quirrel API a bit

### DIFF
--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -67,10 +67,8 @@ class KeyValueFile;
 
 namespace SQCompilation
 {
-  class Node;
+  struct SqASTData;
 }
-
-using SqAstNode = SQCompilation::Node;
 
 #include "sqconfig.h"
 #include <stdio.h>
@@ -253,16 +251,15 @@ SQUIRREL_API SQRESULT sq_compilebuffer(HSQUIRRELVM v,const SQChar *s,SQInteger s
 SQUIRREL_API SQRESULT sq_parsetobinaryast(HSQUIRRELVM v, const SQChar *s, SQInteger size, const SQChar *sourcename, OutputStream *ostream, SQBool raiseerror);
 SQUIRREL_API SQRESULT sq_translatebinaryasttobytecode(HSQUIRRELVM v, const uint8_t *buffer, size_t size, const HSQOBJECT *bindings, SQBool raiseerror);
 
-SQUIRREL_API SqAstNode *sq_parsetoast(HSQUIRRELVM v, const SQChar *s, SQInteger size, const SQChar *sourcename, SQBool raiseerror, Arena *arena);
-SQUIRREL_API SQRESULT sq_translateasttobytecode(HSQUIRRELVM v, SqAstNode *ast, const HSQOBJECT *bindings, const SQChar *sourcename, const SQChar *s, SQInteger size, SQBool raiseerror, SQBool debugInfo);
-SQUIRREL_API void sq_analyseast(HSQUIRRELVM v, SqAstNode *ast, const HSQOBJECT *bindings, const SQChar *sourcename, const SQChar *s, SQInteger size);
+SQUIRREL_API SQCompilation::SqASTData *sq_parsetoast(HSQUIRRELVM v, const SQChar *s, SQInteger size, const SQChar *sourcename, SQBool raiseerror);
+SQUIRREL_API SQRESULT sq_translateasttobytecode(HSQUIRRELVM v, SQCompilation::SqASTData *astData, const HSQOBJECT *bindings, const SQChar *s, SQInteger size, SQBool raiseerror, SQBool debugInfo);
+SQUIRREL_API void sq_analyseast(HSQUIRRELVM v, SQCompilation::SqASTData *astData, const HSQOBJECT *bindings, const SQChar *s, SQInteger size);
 
 
-SQUIRREL_API void sq_dumpast(HSQUIRRELVM v, SqAstNode *ast, OutputStream *s);
+SQUIRREL_API void sq_dumpast(HSQUIRRELVM v, SQCompilation::SqASTData *astData, OutputStream *s);
 SQUIRREL_API void sq_dumpbytecode(HSQUIRRELVM v, HSQOBJECT obj, OutputStream *s);
 
-SQUIRREL_API Arena *sq_createarena(HSQUIRRELVM v, const SQChar *name);
-SQUIRREL_API void sq_destroyarena(HSQUIRRELVM v, Arena *arena);
+SQUIRREL_API void sq_releaseASTData(HSQUIRRELVM v, SQCompilation::SqASTData *astData);
 
 SQUIRREL_API void sq_setcompilationoption(HSQUIRRELVM v, enum CompilationOptions co, bool value);
 SQUIRREL_API bool sq_checkcompilationoption(HSQUIRRELVM v, enum CompilationOptions co);

--- a/sq/sq.cpp
+++ b/sq/sq.cpp
@@ -91,7 +91,7 @@ struct DumpOptions {
   const char *bytecodeDumpFileName;
 };
 
-static void dumpAst_callback(HSQUIRRELVM vm, SqAstNode *ast, void *opts)
+static void dumpAst_callback(HSQUIRRELVM vm, SQCompilation::SqASTData *astData, void *opts)
 {
     if (opts == NULL)
       return;
@@ -103,7 +103,7 @@ static void dumpAst_callback(HSQUIRRELVM vm, SqAstNode *ast, void *opts)
             FileOutputStream fos(dumpOpt->astDumpFileName);
             if (fos.valid())
             {
-                sq_dumpast(vm, ast, &fos);
+                sq_dumpast(vm, astData, &fos);
             }
             else
             {
@@ -113,7 +113,7 @@ static void dumpAst_callback(HSQUIRRELVM vm, SqAstNode *ast, void *opts)
         else
         {
             FileOutputStream fos(stdout);
-            sq_dumpast(vm, ast, &fos);
+            sq_dumpast(vm, astData, &fos);
         }
     }
 }

--- a/sqmodules/sqmodules.h
+++ b/sqmodules/sqmodules.h
@@ -101,7 +101,7 @@ public:
   } compilationOptions;
 
   void *up_data;
-  void (*onAST_cb)(HSQUIRRELVM, SqAstNode *, void *);
+  void (*onAST_cb)(HSQUIRRELVM, SQCompilation::SqASTData *, void *);
   void (*onBytecode_cb)(HSQUIRRELVM, HSQOBJECT, void *);
 
 private:

--- a/squirrel/sqcompiler.cpp
+++ b/squirrel/sqcompiler.cpp
@@ -25,10 +25,11 @@
 #include "sqcompilationcontext.h"
 #include "static_analyser/analyser.h"
 
-using namespace SQCompilation;
+namespace SQCompilation {
 
-RootBlock *ParseToAST(Arena *astArena, SQVM *vm, const char *sourceText, size_t sourceTextSize, const SQChar *sourcename, bool raiseerror) {
-  SQCompilationContext ctx(vm, astArena, sourcename, sourceText, sourceTextSize, raiseerror);
+static RootBlock *parseASTImpl(Arena *astArena, SQVM *vm, const char *sourceText, size_t sourceTextSize, const SQChar *sourcename, bool raiseerror) {
+  Arena parseArena(_ss(vm)->_alloc_ctx, "Parser");
+  SQCompilationContext ctx(vm, &parseArena, sourcename, sourceText, sourceTextSize, raiseerror);
   SQParser p(vm, sourceText, sourceTextSize, sourcename, astArena, ctx);
 
   RootBlock *r = p.parse();
@@ -41,6 +42,27 @@ RootBlock *ParseToAST(Arena *astArena, SQVM *vm, const char *sourceText, size_t 
   return r;
 }
 
+SqASTData *ParseToAST(SQVM *vm, const char *sourceText, size_t sourceTextSize, const SQChar *sourcename, bool raiseerror) {
+
+  void *arenaPtr = sq_vm_malloc(_ss(vm)->_alloc_ctx, sizeof(Arena));
+  Arena *astArena = new (arenaPtr)  Arena(_ss(vm)->_alloc_ctx, "AST");
+
+  RootBlock *r = parseASTImpl(astArena, vm, sourceText, sourceTextSize, sourcename, raiseerror);
+
+  if (!r) {
+    astArena->~Arena();
+    sq_vm_free(_ss(vm)->_alloc_ctx, astArena, sizeof(Arena));
+    return nullptr;
+  }
+
+  SqASTData *astData = (SqASTData *)sq_vm_malloc(_ss(vm)->_alloc_ctx, sizeof(SqASTData));
+
+  astData->astArena = astArena;
+  astData->root = r;
+  astData->sourceName = sourcename;
+
+  return astData;
+}
 
 bool CompileWithAst(SQVM *vm, const char *sourceText, size_t sourceTextSize, const HSQOBJECT *bindings, const SQChar *sourcename, SQObjectPtr &out, bool raiseerror, bool lineinfo)
 {
@@ -49,7 +71,7 @@ bool CompileWithAst(SQVM *vm, const char *sourceText, size_t sourceTextSize, con
 
     Arena astArena(_ss(vm)->_alloc_ctx, "AST");
 
-    RootBlock *r = ParseToAST(&astArena, vm, sourceText, sourceTextSize, sourcename, raiseerror);
+    RootBlock *r = parseASTImpl(&astArena, vm, sourceText, sourceTextSize, sourcename, raiseerror);
 
     if (!r)
       return false;
@@ -65,30 +87,33 @@ bool Compile(SQVM *vm, const char *sourceText, size_t sourceTextSize, const HSQO
     return CompileWithAst(vm, sourceText, sourceTextSize, bindings, sourcename, out, raiseerror, lineinfo);
 }
 
-bool TranslateASTToBytecode(SQVM *vm, SqAstNode *ast, const HSQOBJECT *bindings, const SQChar *sourcename, const char *sourceText, size_t sourceTextSize, SQObjectPtr &out, bool raiseerror, bool lineinfo)
+static bool TranslateASTToBytecodeImpl(SQVM *vm, RootBlock *ast, const HSQOBJECT *bindings, const SQChar *sourcename, const char *sourceText, size_t sourceTextSize, SQObjectPtr &out, bool raiseerror, bool lineinfo)
 {
     Arena cgArena(_ss(vm)->_alloc_ctx, "Codegen");
     SQCompilationContext ctx(vm, &cgArena, sourcename, sourceText, sourceTextSize, raiseerror);
     CodegenVisitor codegen(&cgArena, bindings, vm, sourcename, ctx, lineinfo);
 
-    assert(ast->op() == TO_BLOCK && ast->asStatement()->asBlock()->isRoot());
-
-    return codegen.generate((RootBlock *)ast, out);
+    return codegen.generate(ast, out);
 }
 
-void AnalyseCode(SQVM *vm, SqAstNode *ast, const HSQOBJECT *bindings, const SQChar *sourcename, const char *sourceText, size_t sourceTextSize)
+bool TranslateASTToBytecode(SQVM *vm, SqASTData *astData, const HSQOBJECT *bindings, const char *sourceText, size_t sourceTextSize, SQObjectPtr &out, bool raiseerror, bool lineinfo)
+{
+    return TranslateASTToBytecodeImpl(vm, astData->root, bindings, astData->sourceName, sourceText, sourceTextSize, out, raiseerror, lineinfo);
+}
+
+void AnalyseCode(SQVM *vm, SqASTData *astData, const HSQOBJECT *bindings, const char *sourceText, size_t sourceTextSize)
 {
     Arena saArena(_ss(vm)->_alloc_ctx, "Analyser");
-    SQCompilationContext ctx(vm, &saArena, sourcename, sourceText, sourceTextSize, true);
+    SQCompilationContext ctx(vm, &saArena, astData->sourceName, sourceText, sourceTextSize, true);
 
+    RootBlock *ast = astData->root;
     StaticAnalyser sa(ctx);
 
-    assert(ast->op() == TO_BLOCK && ast->asStatement()->asBlock()->isRoot());
-
-    sa.runAnalysis((RootBlock *)ast);
+    sa.runAnalysis(ast);
 }
 
-bool TranslateBinaryASTToBytecode(SQVM *vm, const uint8_t *buffer, size_t size, const HSQOBJECT *bindings, SQObjectPtr &out, bool raiseerror, bool lineinfo) {
+bool TranslateBinaryASTToBytecode(SQVM *vm, const uint8_t *buffer, size_t size, const HSQOBJECT *bindings, SQObjectPtr &out, bool raiseerror, bool lineinfo)
+{
     Arena astArena(_ss(vm)->_alloc_ctx, "AST");
 
     MemoryInputStream mis(buffer, size);
@@ -100,13 +125,13 @@ bool TranslateBinaryASTToBytecode(SQVM *vm, const uint8_t *buffer, size_t size, 
       return false;
     }
 
-    return TranslateASTToBytecode(vm, r, bindings, sourcename, NULL, 0, out, raiseerror, lineinfo);
+    return TranslateASTToBytecodeImpl(vm, r, bindings, sourcename, NULL, 0, out, raiseerror, lineinfo);
 }
 
 bool ParseAndSaveBinaryAST(SQVM *vm, const char *sourceText, size_t sourceTextSize, const SQChar *sourcename, OutputStream *ostream, bool raiseerror) {
     Arena astArena(_ss(vm)->_alloc_ctx, "AST");
 
-    RootBlock *r = ParseToAST(&astArena, vm, sourceText, sourceTextSize, sourcename, raiseerror);
+    RootBlock *r = parseASTImpl(&astArena, vm, sourceText, sourceTextSize, sourcename, raiseerror);
 
     if (!r) {
         return false;
@@ -117,5 +142,7 @@ bool ParseAndSaveBinaryAST(SQVM *vm, const char *sourceText, size_t sourceTextSi
 
     return true;
 }
+
+}; // SQCompilation
 
 #endif

--- a/squirrel/sqcompiler.h
+++ b/squirrel/sqcompiler.h
@@ -4,15 +4,19 @@
 
 struct SQVM;
 class OutputStream;
+class Arena;
+
 namespace SQCompilation
 {
-  class RootBlock;
-  class Node;
-}
 
-using SqAstNode = SQCompilation::Node;
+class RootBlock;
 
-class Arena;
+struct SqASTData {
+  Arena *astArena;
+  RootBlock *root;
+  const SQChar *sourceName;
+};
+
 
 #define TK_IDENTIFIER   258
 #define TK_STRING_LITERAL   259
@@ -163,10 +167,14 @@ enum SQExpressionContext
 
 typedef void(*CompilerErrorFunc)(void *ud, const SQChar *s);
 bool Compile(SQVM *vm, const char *sourceText, size_t sourceTextSize, const HSQOBJECT *bindings, const SQChar *sourcename, SQObjectPtr &out, bool raiseerror, bool lineinfo);
+
 bool CompileWithAst(SQVM *vm, const char *sourceText, size_t sourceTextSize, const HSQOBJECT *bindings, const SQChar *sourcename, SQObjectPtr &out, bool raiseerror, bool lineinfo);
-SQCompilation::RootBlock *ParseToAST(Arena *astArena, SQVM *vm, const char *sourceText, size_t sourceTextSize, const SQChar *sourcename, bool raiseerror);
+
+SqASTData *ParseToAST(SQVM *vm, const char *sourceText, size_t sourceTextSize, const SQChar *sourcename, bool raiseerror);
 bool ParseAndSaveBinaryAST(SQVM *vm, const char *sourceText, size_t sourceTextSize, const SQChar *sourcename, OutputStream *ostream, bool raiseerror);
-bool TranslateASTToBytecode(SQVM *vm, SqAstNode *ast, const HSQOBJECT *bindings, const SQChar *sourcename, const char *sourceText, size_t sourceTextSize, SQObjectPtr &out, bool raiseerror, bool lineinfo);
+bool TranslateASTToBytecode(SQVM *vm, SqASTData *astData, const HSQOBJECT *bindings, const char *sourceText, size_t sourceTextSize, SQObjectPtr &out, bool raiseerror, bool lineinfo);
 bool TranslateBinaryASTToBytecode(SQVM *vm, const uint8_t *buffer, size_t size, const HSQOBJECT *bindings, SQObjectPtr &out, bool raiseerror, bool lineinfo);
-void AnalyseCode(SQVM *vm, SqAstNode *ast, const HSQOBJECT *bindings, const SQChar *sourcename, const char *sourceText, size_t sourceTextSize);
+void AnalyseCode(SQVM *vm, SqASTData *astData, const HSQOBJECT *bindings, const char *sourceText, size_t sourceTextSize);
+
+}; // SQCompilation
 #endif //_SQCOMPILER_H_


### PR DESCRIPTION
 - wrap compiler interface into SQCompilation namespace
 - use a special umbrela struct instead of raw AST node ptr as a parsing result