### PR TITLE
Fix 'potentially-nulled-ops' warning in SA

### DIFF
--- a/squirrel/static_analyser/analyser.cpp
+++ b/squirrel/static_analyser/analyser.cpp
@@ -2493,9 +2493,11 @@ void CheckerVisitor::checkPotentiallyNullableOperands(const BinExpr *bin) {
   if (effectsOnly)
     return;
 
-  bool isRelOp = isRelationOperator(bin->op());
-  bool isArithOp = isPureArithOperator(bin->op());
-  bool isAssign = bin->op() == TO_ASSIGN || bin->op() == TO_INEXPR_ASSIGN || bin->op() == TO_NEWSLOT;
+  enum TreeOp op = bin->op();
+
+  bool isRelOp = isBoolRelationOperator(op);
+  bool isArithOp = isPureArithOperator(op);
+  bool isAssign = op == TO_ASSIGN || op == TO_INEXPR_ASSIGN || op == TO_NEWSLOT;
 
   if (!isRelOp && !isArithOp && !isAssign)
     return;

--- a/testData/static_analyser/w200_3wcmp.nut
+++ b/testData/static_analyser/w200_3wcmp.nut
@@ -1,0 +1,9 @@
+
+
+local function _itemsSorter(a, b) { // -return-different-types
+    a = a?.item
+    b = b?.item
+    if (!a || !b)
+      return a <=> b
+    return 42
+  }


### PR DESCRIPTION
Do not report warning on '<=>' operator since
it could have null as it's operand