### PR TITLE
added missing ctors and operator= (required due to custom dtor)

### DIFF
--- a/include/sqstdio.h
+++ b/include/sqstdio.h
@@ -7,6 +7,11 @@
 #define SQSTD_STREAM_TYPE_TAG 0x80000000
 
 struct SQStream {
+    SQStream() = default;
+    SQStream(const SQStream&) = default;
+    SQStream(SQStream&&) = default;
+    SQStream& operator=(const SQStream&) = default;
+    SQStream& operator=(SQStream&&) = default;
     virtual ~SQStream() {}
     virtual SQInteger Read(void *buffer, SQInteger size) = 0;
     virtual SQInteger Write(void *buffer, SQInteger size) = 0;

--- a/squirrel/sqvm.h
+++ b/squirrel/sqvm.h
@@ -24,6 +24,7 @@ struct SQExceptionTrap{
     SQExceptionTrap() {}
     SQExceptionTrap(SQInteger ss, SQInteger stackbase,SQInstruction *ip, SQInteger ex_target){ _stacksize = ss; _stackbase = stackbase; _ip = ip; _extarget = ex_target;}
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
+    SQExceptionTrap &operator=(const SQExceptionTrap &et) = default;
     SQInteger _stackbase;
     SQInteger _stacksize;
     SQInstruction *_ip;


### PR DESCRIPTION
To be able to compile with vc2022 (with C5267 warning turned on)