### PR TITLE
Fix build with Clang and GCC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ bin/
 lib/
 
 # CMake output
-build/
+build*/
 
 # Folders created at documentation generation
 doc/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 set(CMAKE_CXX_STANDARD 17)
 
-if(CMAKE_COMPILER_IS_GNUCXX)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti;-fno-exceptions>"
     -fno-strict-aliasing
@@ -25,8 +25,14 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     "$<$<CONFIG:Release>:-O3>"
     "$<$<CONFIG:RelWithDebInfo>:-O3;-g>"
     "$<$<CONFIG:MinSizeRel>:-Os>"
-    "$<$<CONFIG:Debug>:-pg;-pie;-gstabs;-g3;-Og>"
-    )
+  )
+  # Debug flags
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options("$<$<CONFIG:Debug>:-g3;-Og>")
+  else()
+    # Clang debug flags
+    add_compile_options("$<$<CONFIG:Debug>:-g;-Og>")
+  endif()
 elseif(MSVC)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)

--- a/sq/CMakeLists.txt
+++ b/sq/CMakeLists.txt
@@ -2,8 +2,7 @@ add_executable(sq sq.cpp)
 
 target_link_libraries(sq squirrel sqstdlib sqmodules quirrel-compiler)
 target_include_directories(sq PRIVATE
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/sqmodules>"
+  # include/ and sqmodules/ are transitive from linked libraries
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/sqrat/include>"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>" # Needed for <squirrel/sqtypeparser.h>
   )

--- a/sqmodules/CMakeLists.txt
+++ b/sqmodules/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(squirrel::sqmodules ALIAS sqmodules)
 target_link_libraries(sqmodules sqstdlib squirrel)
 target_include_directories(sqmodules PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/sqmodules>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
   PRIVATE
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/sqrat/include>"

--- a/sqmodules/deffileaccess.cpp
+++ b/sqmodules/deffileaccess.cpp
@@ -6,6 +6,7 @@
 #  include <io.h>
 #else
 #  include <unistd.h>
+#  include <limits.h>
 #  define _access access
 #endif
 

--- a/sqrat/include/sqrat/sqratClass.h
+++ b/sqrat/include/sqrat/sqratClass.h
@@ -141,20 +141,6 @@ public:
 
 public:
 
-    /// Assigns a static class slot a value
-    template<class V>
-    Class& SetStaticValue(const SQChar* name, const V& val) {
-        BindValue<V>(name, val, true);
-        return *this;
-    }
-
-    /// Assigns a class slot a value
-    template<class V>
-    Class& SetValue(const SQChar* name, const V& val) {
-        BindValue<V>(name, val, false);
-        return *this;
-    }
-
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     /// Binds a class variable of type <V>
     ///

--- a/squirrel/CMakeLists.txt
+++ b/squirrel/CMakeLists.txt
@@ -29,4 +29,5 @@ target_include_directories(squirrel PUBLIC
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
   PRIVATE
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/internal>"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/squirrel>"
   )

--- a/squirrel/compiler/CMakeLists.txt
+++ b/squirrel/compiler/CMakeLists.txt
@@ -15,6 +15,12 @@ set(COMPILER_SRC
 add_library(quirrel-compiler STATIC ${COMPILER_SRC})
 add_library(quirrel::compiler ALIAS quirrel-compiler)
 
+# The compiler needs exceptions for error handling (CompilerError)
+target_compile_options(quirrel-compiler PRIVATE
+  "$<$<CXX_COMPILER_ID:GNU,Clang>:-fexceptions>"
+  "$<$<CXX_COMPILER_ID:MSVC>:/EHsc>"
+)
+
 target_include_directories(quirrel-compiler PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"


### PR DESCRIPTION
Fix CMake configuration for GCC and Clang compatibility.
Added #include <limits.h> for PATH_MAX on non-Windows systems.
Removed unused SetValue()/SetStaticValue() methods from Sqrat Class class.