### PR TITLE
clock(): microsecond resolution on Windows

### DIFF
--- a/sqstdlib/sqstddatetime.cpp
+++ b/sqstdlib/sqstddatetime.cpp
@@ -4,11 +4,31 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sqstddatetime.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
 
 
 static SQInteger _datetime_clock(HSQUIRRELVM v)
 {
+#ifdef _WIN32
+    // the CRT clock() advances once a millisecond on Windows; QueryPerformanceCounter
+    // keeps the same seconds-since-start reading at microsecond resolution
+    static LARGE_INTEGER freq, start;
+    static bool started = false;
+    LARGE_INTEGER now;
+    if (!started) {
+        QueryPerformanceFrequency(&freq);
+        QueryPerformanceCounter(&start);
+        started = true;
+    }
+    QueryPerformanceCounter(&now);
+    sq_pushfloat(v, (SQFloat)((double)(now.QuadPart - start.QuadPart) / (double)freq.QuadPart));
+#else
     sq_pushfloat(v,((SQFloat)clock())/(SQFloat)CLOCKS_PER_SEC);
+#endif
     return 1;
 }
 


### PR DESCRIPTION
## Why

`clock()` from the `datetime` module wraps the CRT `clock()`. On Windows that counter advances once a millisecond, so a benchmark that times a body under a few milliseconds reads `0.000` or `0.001` - every Quirrel number in the daslang cross-language benchmark table on Windows is an exact millisecond multiple, and the `queen` row rounds to zero.

## What

On `_WIN32`, `_datetime_clock` reads `QueryPerformanceCounter` and returns the seconds elapsed since its first call, divided out at `double` precision before narrowing to `SQFloat`, so the value keeps the "seconds since the process started" shape of `clock()` while resolving to a fraction of a microsecond. POSIX builds keep `clock()`, which already resolves to microseconds there.

No API change; `clock()` still returns a float in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

